### PR TITLE
Add notebook to create DED21 dataset

### DIFF
--- a/create_ded21_corpus.ipynb
+++ b/create_ded21_corpus.ipynb
@@ -1,0 +1,630 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Create Dutch Election Debate 21 Corpus"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This notebook creates the dataset from the Dutch Election Debate 21 (DED21) corpus (see this [blog post](https://stukroodvlees.nl/welke-lijsttrekkers-lacht-het-meest-en-hoe/) for details). The corpus consists of a single video file (with audio signal) that is 1.45 hours long. The video features six Dutch party candidates, two moderators, and speakers from the audience. The audio signal has been annotated to the extent that all speech segments of the six party candidates are labeled.\n",
+    "\n",
+    "To run the notebook, the folder `dutch-debate-corpus` needs to be in the same directory."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from copy import deepcopy\n",
+    "from moviepy.editor import VideoFileClip\n",
+    "from rttm import RttmObj, RttmSeq\n",
+    "from scipy.io import wavfile\n",
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "import seaborn as sns\n",
+    "import os\n",
+    "\n",
+    "DATA_DIR = \"dutch-debate-corpus\"\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def cut_time(time):\n",
+    "    time_split = str(time).split(\":\")\n",
+    "    if len(time_split) == 2 or (time_split[-1] == \"00\" and time_split[0] != \"01\"):\n",
+    "        out = \"00:\" + \":\".join(time_split[:2])\n",
+    "    else:\n",
+    "        out = \":\".join(time_split[:3])\n",
+    "    return out\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The annotation file is read and the start and end time stamps of the labeled speech segments are extracted."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "speaker_turns = pd.read_csv(os.path.join(DATA_DIR, \"speaking_turns.csv\"))\n",
+    "speaker_turns[\"audio_start\"] = pd.to_timedelta(\n",
+    "    speaker_turns[\"audio.start\"].apply(cut_time))\n",
+    "speaker_turns[\"audio_end\"] = pd.to_timedelta(\n",
+    "    speaker_turns[\"audio.end\"].apply(cut_time))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The extracted annotations are converted into RTTM format and saved as a reference file."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "segments = []\n",
+    "\n",
+    "for row in speaker_turns.itertuples():\n",
+    "    if not pd.isna(row.spkr_name) and not pd.isna(row.audio_start) and not pd.isna(row.audio_end):\n",
+    "        new_segment = RttmObj(\n",
+    "            type=\"SPEAKER\",\n",
+    "            file=os.path.join(DATA_DIR, \"ded21_audio.wav\"),\n",
+    "            chnl=1,\n",
+    "            tbeg=float(row.audio_start.seconds),\n",
+    "            tdur=float(row.audio_end.seconds) - float(row.audio_start.seconds),\n",
+    "            ortho=None,\n",
+    "            stype=None,\n",
+    "            name=row.spkr_name,\n",
+    "            conf=None\n",
+    "        )\n",
+    "        segments.append(new_segment)\n",
+    "\n",
+    "\n",
+    "rttm_seq = RttmSeq(sequence=segments).sort()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "type\tfile\tchnl\ttbeg\ttdur\tortho\tstype\tname\tconf\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t343.0\t34.0\t<NA>\t<NA>\tWilders\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t381.0\t32.0\t<NA>\t<NA>\tMarijnissen\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t417.0\t30.0\t<NA>\t<NA>\tHoekstra\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t450.0\t33.0\t<NA>\t<NA>\tKaag\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t485.0\t32.0\t<NA>\t<NA>\tRutte\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t521.0\t28.0\t<NA>\t<NA>\tKlaver\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t572.0\t43.0\t<NA>\t<NA>\tKaag\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t638.0\t75.0\t<NA>\t<NA>\tRutte\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t715.0\t48.0\t<NA>\t<NA>\tWilders\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t769.0\t44.0\t<NA>\t<NA>\tHoekstra\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t819.0\t61.0\t<NA>\t<NA>\tMarijnissen\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t908.0\t79.0\t<NA>\t<NA>\tKlaver\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t995.0\t19.0\t<NA>\t<NA>\tWilders\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t1018.0\t35.0\t<NA>\t<NA>\tKaag\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t1055.0\t4.0\t<NA>\t<NA>\tHoekstra\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t1185.0\t62.0\t<NA>\t<NA>\tKaag\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t1275.0\t11.0\t<NA>\t<NA>\tKaag\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t1298.0\t2.0\t<NA>\t<NA>\tKaag\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t1335.0\t31.0\t<NA>\t<NA>\tKaag\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t1560.0\t4.0\t<NA>\t<NA>\tHoekstra\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t1577.0\t43.0\t<NA>\t<NA>\tHoekstra\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t1634.0\t32.0\t<NA>\t<NA>\tHoekstra\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t1684.0\t14.0\t<NA>\t<NA>\tHoekstra\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t1703.0\t18.0\t<NA>\t<NA>\tHoekstra\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t1736.0\t29.0\t<NA>\t<NA>\tHoekstra\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t1891.0\t43.0\t<NA>\t<NA>\tMarijnissen\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t1935.0\t37.0\t<NA>\t<NA>\tRutte\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t1976.0\t35.0\t<NA>\t<NA>\tKaag\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t2014.0\t27.0\t<NA>\t<NA>\tWilders\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t2054.0\t29.0\t<NA>\t<NA>\tKlaver\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t2087.0\t28.0\t<NA>\t<NA>\tHoekstra\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t2128.0\t52.0\t<NA>\t<NA>\tRutte\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t2181.0\t41.0\t<NA>\t<NA>\tWilders\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t2251.0\t59.0\t<NA>\t<NA>\tKaag\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t2302.0\t49.0\t<NA>\t<NA>\tWilders\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t2365.0\t38.0\t<NA>\t<NA>\tHoekstra\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t2432.0\t57.0\t<NA>\t<NA>\tKlaver\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t2492.0\t55.0\t<NA>\t<NA>\tMarijnissen\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t2554.0\t36.0\t<NA>\t<NA>\tRutte\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t2693.0\t63.0\t<NA>\t<NA>\tRutte\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t2776.0\t31.0\t<NA>\t<NA>\tRutte\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t2830.0\t25.0\t<NA>\t<NA>\tRutte\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t2878.0\t4.0\t<NA>\t<NA>\tRutte\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t2888.0\t9.0\t<NA>\t<NA>\tRutte\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t3051.0\t29.0\t<NA>\t<NA>\tKlaver\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t3082.0\t35.0\t<NA>\t<NA>\tWilders\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t3120.0\t28.0\t<NA>\t<NA>\tKaag\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t3154.0\t25.0\t<NA>\t<NA>\tHoekstra\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t3183.0\t35.0\t<NA>\t<NA>\tMarijnissen\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t3220.0\t18.0\t<NA>\t<NA>\tRutte\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t3250.0\t38.0\t<NA>\t<NA>\tWilders\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t3290.0\t42.0\t<NA>\t<NA>\tMarijnissen\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t3332.0\t62.0\t<NA>\t<NA>\tRutte\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t3395.0\t44.0\t<NA>\t<NA>\tKlaver\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t3439.0\t52.0\t<NA>\t<NA>\tRutte\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t3492.0\t39.0\t<NA>\t<NA>\tKaag\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t3538.0\t26.0\t<NA>\t<NA>\tRutte\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t3566.0\t47.0\t<NA>\t<NA>\tHoekstra\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t3620.0\t40.0\t<NA>\t<NA>\tKlaver\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t3673.0\t17.0\t<NA>\t<NA>\tRutte\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t3691.0\t22.0\t<NA>\t<NA>\tHoekstra\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t3842.0\t32.0\t<NA>\t<NA>\tWilders\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t3919.0\t134.0\t<NA>\t<NA>\tWilders\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t4143.0\t19.0\t<NA>\t<NA>\tRutte\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t4164.0\t14.0\t<NA>\t<NA>\tKaag\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t4181.0\t32.0\t<NA>\t<NA>\tWilders\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t4215.0\t38.0\t<NA>\t<NA>\tMarijnissen\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t4255.0\t33.0\t<NA>\t<NA>\tKlaver\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t4290.0\t38.0\t<NA>\t<NA>\tHoekstra\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t4331.0\t23.0\t<NA>\t<NA>\tRutte\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t4366.0\t22.0\t<NA>\t<NA>\tRutte\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t4397.0\t25.0\t<NA>\t<NA>\tHoekstra\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t4451.0\t64.0\t<NA>\t<NA>\tMarijnissen\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t4534.0\t43.0\t<NA>\t<NA>\tWilders\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t4581.0\t43.0\t<NA>\t<NA>\tKaag\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t4626.0\t27.0\t<NA>\t<NA>\tKlaver\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t4654.0\t43.0\t<NA>\t<NA>\tRutte\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t4704.0\t50.0\t<NA>\t<NA>\tHoekstra\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t4823.0\t16.0\t<NA>\t<NA>\tBurger\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t4840.0\t6.0\t<NA>\t<NA>\tKlaver\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t4847.0\t18.0\t<NA>\t<NA>\tBurger\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t4866.0\t3.0\t<NA>\t<NA>\tKlaver\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t4870.0\t8.0\t<NA>\t<NA>\tBurger\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t4886.0\t34.0\t<NA>\t<NA>\tKlaver\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t4920.0\t14.0\t<NA>\t<NA>\tBurger\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t4935.0\t23.0\t<NA>\t<NA>\tKlaver\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t4961.0\t12.0\t<NA>\t<NA>\tBurger\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t4974.0\t17.0\t<NA>\t<NA>\tKlaver\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t4999.0\t19.0\t<NA>\t<NA>\tKlaver\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t5147.0\t27.0\t<NA>\t<NA>\tBurger\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t5175.0\t56.0\t<NA>\t<NA>\tMarijnissen\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t5232.0\t26.0\t<NA>\t<NA>\tBurger\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t5259.0\t52.0\t<NA>\t<NA>\tMarijnissen\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t5331.0\t42.0\t<NA>\t<NA>\tMarijnissen\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t5378.0\t26.0\t<NA>\t<NA>\tBurger\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t5503.0\t31.0\t<NA>\t<NA>\tHoekstra\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t5538.0\t39.0\t<NA>\t<NA>\tKaag\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t5581.0\t38.0\t<NA>\t<NA>\tWilders\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t5620.0\t40.0\t<NA>\t<NA>\tMarijnissen\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t5668.0\t28.0\t<NA>\t<NA>\tRutte\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t5698.0\t60.0\t<NA>\t<NA>\tKlaver\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t5763.0\t62.0\t<NA>\t<NA>\tKaag\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t5840.0\t29.0\t<NA>\t<NA>\tHoekstra\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t5874.0\t53.0\t<NA>\t<NA>\tWilders\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t5930.0\t60.0\t<NA>\t<NA>\tRutte\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t5996.0\t86.0\t<NA>\t<NA>\tMarijnissen\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t6084.0\t49.0\t<NA>\t<NA>\tKlaver\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t6137.0\t26.0\t<NA>\t<NA>\tHoekstra\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t6169.0\t23.0\t<NA>\t<NA>\tKaag\t<NA>\t\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(rttm_seq)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rttm_seq.write(os.path.join(DATA_DIR, \"ref_ded21_audio.rttm\"))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The audio signal is separated from the video file and saved."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def convert_video_to_audio(video_file, audio_file, sample_rate=16000):\n",
+    "    with VideoFileClip(video_file) as clip:\n",
+    "        clip.audio.write_audiofile(audio_file, fps=sample_rate)\n",
+    "\n",
+    "    print(f\"Converted video file {video_file} to audio file {audio_file}\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "MoviePy - Writing audio in dutch-debate-corpus\\ded21_audio.wav\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "                                                                        "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "MoviePy - Done.\n",
+      "Converted video file dutch-debate-corpus\\ded21_video.mp4 to audio file dutch-debate-corpus\\ded21_audio.wav\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r"
+     ]
+    }
+   ],
+   "source": [
+    "convert_video_to_audio(os.path.join(DATA_DIR, \"ded21_video.mp4\"),\n",
+    "                       os.path.join(DATA_DIR, \"ded21_audio.wav\"))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The labeled segments are extracted from the audio signal. Instead of cutting them together right after each other, a short white noise segment is inserted in between the segments to simulated non-speech segments. The white noise segments have a random length between 1s and 5s. A new RTTM file is created that contains the reference for the new audio signal."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def generate_white_noise(size, amplitude):\n",
+    "    return amplitude*np.random.normal(0.0, 1.0, size=size).astype(np.int16)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def segment_audio(audio_file, rttm_seq):\n",
+    "    sample_rate, signal = wavfile.read(audio_file)\n",
+    "    amplitude = np.iinfo(np.int16).max\n",
+    "    new_signal = np.zeros((0, 2), dtype=np.int16)\n",
+    "    new_rttm_seq = deepcopy(rttm_seq)\n",
+    "\n",
+    "    for i, seg in enumerate(rttm_seq.sequence):\n",
+    "        start_frame = int(seg.tbeg*sample_rate)\n",
+    "        end_frame = int((seg.tbeg+seg.tdur)*sample_rate)\n",
+    "        noise_dur = np.random.choice(5)+1\n",
+    "        new_signal = np.append(new_signal, generate_white_noise(\n",
+    "            (int(sample_rate*noise_dur), 2), amplitude), axis=0)\n",
+    "        new_signal = np.append(\n",
+    "            new_signal, signal[start_frame:end_frame, :], axis=0)\n",
+    "        new_seg = new_rttm_seq.sequence[i]\n",
+    "\n",
+    "        if i == 0:\n",
+    "            new_seg.tbeg = noise_dur\n",
+    "        else:\n",
+    "            new_prev_seg = new_rttm_seq.sequence[i-1]\n",
+    "            new_seg.tbeg = new_prev_seg.tbeg+new_prev_seg.tdur + noise_dur\n",
+    "\n",
+    "    wavfile.write(audio_file, sample_rate, new_signal)\n",
+    "\n",
+    "    return new_rttm_seq\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "np.random.seed(10)\n",
+    "\n",
+    "new_rttm_seq = segment_audio(os.path.join(\n",
+    "    DATA_DIR, \"ded21_audio.wav\"), rttm_seq)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "type\tfile\tchnl\ttbeg\ttdur\tortho\tstype\tname\tconf\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t2\t34.0\t<NA>\t<NA>\tWilders\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t41.0\t32.0\t<NA>\t<NA>\tMarijnissen\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t76.0\t30.0\t<NA>\t<NA>\tHoekstra\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t110.0\t33.0\t<NA>\t<NA>\tKaag\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t145.0\t32.0\t<NA>\t<NA>\tRutte\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t179.0\t28.0\t<NA>\t<NA>\tKlaver\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t210.0\t43.0\t<NA>\t<NA>\tKaag\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t255.0\t75.0\t<NA>\t<NA>\tRutte\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t333.0\t48.0\t<NA>\t<NA>\tWilders\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t382.0\t44.0\t<NA>\t<NA>\tHoekstra\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t427.0\t61.0\t<NA>\t<NA>\tMarijnissen\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t489.0\t79.0\t<NA>\t<NA>\tKlaver\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t570.0\t19.0\t<NA>\t<NA>\tWilders\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t591.0\t35.0\t<NA>\t<NA>\tKaag\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t630.0\t4.0\t<NA>\t<NA>\tHoekstra\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t635.0\t62.0\t<NA>\t<NA>\tKaag\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t698.0\t11.0\t<NA>\t<NA>\tKaag\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t713.0\t2.0\t<NA>\t<NA>\tKaag\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t717.0\t31.0\t<NA>\t<NA>\tKaag\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t751.0\t4.0\t<NA>\t<NA>\tHoekstra\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t757.0\t43.0\t<NA>\t<NA>\tHoekstra\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t804.0\t32.0\t<NA>\t<NA>\tHoekstra\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t837.0\t14.0\t<NA>\t<NA>\tHoekstra\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t855.0\t18.0\t<NA>\t<NA>\tHoekstra\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t878.0\t29.0\t<NA>\t<NA>\tHoekstra\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t912.0\t43.0\t<NA>\t<NA>\tMarijnissen\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t958.0\t37.0\t<NA>\t<NA>\tRutte\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t997.0\t35.0\t<NA>\t<NA>\tKaag\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t1037.0\t27.0\t<NA>\t<NA>\tWilders\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t1065.0\t29.0\t<NA>\t<NA>\tKlaver\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t1098.0\t28.0\t<NA>\t<NA>\tHoekstra\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t1127.0\t52.0\t<NA>\t<NA>\tRutte\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t1181.0\t41.0\t<NA>\t<NA>\tWilders\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t1227.0\t59.0\t<NA>\t<NA>\tKaag\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t1291.0\t49.0\t<NA>\t<NA>\tWilders\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t1342.0\t38.0\t<NA>\t<NA>\tHoekstra\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t1382.0\t57.0\t<NA>\t<NA>\tKlaver\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t1444.0\t55.0\t<NA>\t<NA>\tMarijnissen\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t1500.0\t36.0\t<NA>\t<NA>\tRutte\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t1537.0\t63.0\t<NA>\t<NA>\tRutte\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t1603.0\t31.0\t<NA>\t<NA>\tRutte\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t1638.0\t25.0\t<NA>\t<NA>\tRutte\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t1664.0\t4.0\t<NA>\t<NA>\tRutte\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t1671.0\t9.0\t<NA>\t<NA>\tRutte\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t1681.0\t29.0\t<NA>\t<NA>\tKlaver\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t1713.0\t35.0\t<NA>\t<NA>\tWilders\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t1750.0\t28.0\t<NA>\t<NA>\tKaag\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t1779.0\t25.0\t<NA>\t<NA>\tHoekstra\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t1807.0\t35.0\t<NA>\t<NA>\tMarijnissen\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t1844.0\t18.0\t<NA>\t<NA>\tRutte\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t1866.0\t38.0\t<NA>\t<NA>\tWilders\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t1908.0\t42.0\t<NA>\t<NA>\tMarijnissen\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t1953.0\t62.0\t<NA>\t<NA>\tRutte\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t2018.0\t44.0\t<NA>\t<NA>\tKlaver\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t2064.0\t52.0\t<NA>\t<NA>\tRutte\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t2120.0\t39.0\t<NA>\t<NA>\tKaag\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t2163.0\t26.0\t<NA>\t<NA>\tRutte\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t2194.0\t47.0\t<NA>\t<NA>\tHoekstra\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t2245.0\t40.0\t<NA>\t<NA>\tKlaver\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t2289.0\t17.0\t<NA>\t<NA>\tRutte\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t2307.0\t22.0\t<NA>\t<NA>\tHoekstra\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t2330.0\t32.0\t<NA>\t<NA>\tWilders\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t2363.0\t134.0\t<NA>\t<NA>\tWilders\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t2501.0\t19.0\t<NA>\t<NA>\tRutte\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t2523.0\t14.0\t<NA>\t<NA>\tKaag\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t2541.0\t32.0\t<NA>\t<NA>\tWilders\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t2578.0\t38.0\t<NA>\t<NA>\tMarijnissen\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t2618.0\t33.0\t<NA>\t<NA>\tKlaver\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t2655.0\t38.0\t<NA>\t<NA>\tHoekstra\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t2698.0\t23.0\t<NA>\t<NA>\tRutte\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t2724.0\t22.0\t<NA>\t<NA>\tRutte\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t2751.0\t25.0\t<NA>\t<NA>\tHoekstra\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t2781.0\t64.0\t<NA>\t<NA>\tMarijnissen\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t2848.0\t43.0\t<NA>\t<NA>\tWilders\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t2893.0\t43.0\t<NA>\t<NA>\tKaag\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t2941.0\t27.0\t<NA>\t<NA>\tKlaver\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t2970.0\t43.0\t<NA>\t<NA>\tRutte\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t3014.0\t50.0\t<NA>\t<NA>\tHoekstra\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t3069.0\t16.0\t<NA>\t<NA>\tBurger\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t3088.0\t6.0\t<NA>\t<NA>\tKlaver\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t3095.0\t18.0\t<NA>\t<NA>\tBurger\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t3115.0\t3.0\t<NA>\t<NA>\tKlaver\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t3122.0\t8.0\t<NA>\t<NA>\tBurger\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t3133.0\t34.0\t<NA>\t<NA>\tKlaver\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t3168.0\t14.0\t<NA>\t<NA>\tBurger\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t3183.0\t23.0\t<NA>\t<NA>\tKlaver\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t3210.0\t12.0\t<NA>\t<NA>\tBurger\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t3223.0\t17.0\t<NA>\t<NA>\tKlaver\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t3241.0\t19.0\t<NA>\t<NA>\tKlaver\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t3265.0\t27.0\t<NA>\t<NA>\tBurger\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t3295.0\t56.0\t<NA>\t<NA>\tMarijnissen\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t3355.0\t26.0\t<NA>\t<NA>\tBurger\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t3383.0\t52.0\t<NA>\t<NA>\tMarijnissen\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t3437.0\t42.0\t<NA>\t<NA>\tMarijnissen\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t3483.0\t26.0\t<NA>\t<NA>\tBurger\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t3513.0\t31.0\t<NA>\t<NA>\tHoekstra\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t3545.0\t39.0\t<NA>\t<NA>\tKaag\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t3586.0\t38.0\t<NA>\t<NA>\tWilders\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t3627.0\t40.0\t<NA>\t<NA>\tMarijnissen\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t3671.0\t28.0\t<NA>\t<NA>\tRutte\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t3701.0\t60.0\t<NA>\t<NA>\tKlaver\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t3762.0\t62.0\t<NA>\t<NA>\tKaag\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t3829.0\t29.0\t<NA>\t<NA>\tHoekstra\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t3862.0\t53.0\t<NA>\t<NA>\tWilders\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t3917.0\t60.0\t<NA>\t<NA>\tRutte\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t3981.0\t86.0\t<NA>\t<NA>\tMarijnissen\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t4072.0\t49.0\t<NA>\t<NA>\tKlaver\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t4125.0\t26.0\t<NA>\t<NA>\tHoekstra\t<NA>\t\n",
+      "SPEAKER\tdutch-debate-corpus\\ded21_audio.wav\t1\t4156.0\t23.0\t<NA>\t<NA>\tKaag\t<NA>\t\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(new_rttm_seq)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[]"
+      ]
+     },
+     "execution_count": 31,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYcAAAEGCAYAAACO8lkDAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/YYfK9AAAACXBIWXMAAAsTAAALEwEAmpwYAAASsUlEQVR4nO3da7BlZX3n8e+vaQRFIxA6nbbpniaGaAhR1GOU1rFQMxk0F0xCBIcybQ2ZZiqaqLEyBbFqNFV5oZWLuU2MrRLQGCQaUNREg4iXGRSnYRAakEAUQkNLtzEqY2bQpv/zYq0u9pznXHaf0/tyDt9P1a6zbnut/37O5XfW7VmpKiRJGrRm0gVIkqaP4SBJahgOkqSG4SBJahgOkqTG2kkXMIwTTjihtmzZMukyJGlFueGGG75eVeuW8t4VEQ5btmxh586dky5DklaUJPcs9b0eVpIkNQwHSVLDcJAkNQwHSVLDcJAkNQwHSVLDcJAkNQwHSVLDcJAkNQyHFWTjps0kWdZr46bNk/4YklaAFdF9hjr3776Xc95x3bLWcfkFWw9TNZJWM/ccJEkNw0GS1DAcJEkNw0GS1DAcJEkNw0GS1DAcJEkNw0GS1DAcJEkNw0GS1DAcJEkNw0GS1DAcJEmNkYVDkk1Jrk1yW5Jbk7y2n358kquT3Nl/PW5UNUiSlmaUew77gTdU1SnAc4FXJzkFuBC4pqpOBq7pxyVJU2Rk4VBVe6rqxn74QeB2YCNwFnBpv9ilwMtGVYMkaWnGcs4hyRbgGcD1wPqq2tPP+hqwfhw1SJKGN/JwSPJ44G+A11XVtwfnVVUBNc/7tifZmWTnvn37Rl3mo8eatT5qVNKiRvqY0CRH0gXD+6rqin7yA0k2VNWeJBuAvXO9t6p2ADsAZmZm5gwQLcGB/T5qVNKiRnm1UoB3A7dX1R8MzLoK2NYPbwM+PKoaJElLM8o9h+cBrwRuSXJTP+23gLcAf53kfOAe4OUjrEGStAQjC4eq+u9A5pn94lFtV5K0fN4hLUlqGA6SpIbhIElqGA6SpIbhIElqGA6SpIbhIElqGA6SpIbhIElqGA6SpIbhIElqGA6SpIbhIElqGA6SpIbhIElqGA6SpIbhIElqGA6SpIbhIElqGA6SpIbhIElqGA6SpIbhIElqGA6SpIbhIElqGA6SpIbhIElqGA6SpIbhIElqGA6SpIbhIElqGA6SpIbhIElqGA6SpIbhIElqGA6SpIbhIElqGA6SpMbIwiHJxUn2Jtk1MO3NSe5LclP/eumoti9JWrpR7jlcApw5x/S3VdVp/etvR7h9SdISjSwcquqzwDdGtX5J0uhM4pzDa5Lc3B92Om4C25ckLWLc4fB24MnAacAe4PfnWzDJ9iQ7k+zct2/fmMrTUNasJcmyXhs3bZ70p5C0gLXj3FhVPXBwOMk7gY8usOwOYAfAzMxMjb46De3Afs55x3XLWsXlF2w9TMVIGoWx7jkk2TAw+vPArvmWlSRNzsj2HJJcBpwBnJBkN/Am4IwkpwEF3A1cMKrtS5KWbmThUFWvmGPyu0e1PUnS4eMd0pKkhuEgSWoYDpKkhuEgSWoYDpKkhuEgSWoYDpKkhuEgSWoYDpKkhuEgSWoYDpKkhuEgSWoYDpKkhuEwJhs3bV7209MkaVzG+iS4R7P7d9/r09MkrRhD7Tkked4w0yRJq8Owh5X+ZMhpkqRVYMHDSklOB7YC65L8xsCs7wOOGGVhkqTJWeycw2OAx/fLPWFg+reBs0dVlCRpshYMh6r6DPCZJJdU1T1jqkmSNGHDXq10VJIdwJbB91TVi0ZRlCRpsoYNhw8Afw68C3h4dOVIkqbBsOGwv6rePtJKJElTY9hLWT+S5FeTbEhy/MHXSCuTJE3MsHsO2/qvvzkwrYAfOrzlSJKmwVDhUFUnjboQSdL0GCockvzyXNOr6j2HtxxJ0jQY9rDSsweGjwZeDNwIGA6StAoNe1jp1wbHkxwLvH8UBUmSJm+pz3P4DuB5CElapYY95/ARuquToOtw70eBvx5VUZKkyRr2nMPvDQzvB+6pqt0jqEeSNAWGOqzUd8D3ZbqeWY8DvjvKoiRJkzXsk+BeDnwR+CXg5cD1SeyyW5JWqWEPK70ReHZV7QVIsg74JPDBURUmSZqcYa9WWnMwGHr/fAjvlSStMMPuOXw8ySeAy/rxc4C/HU1JkqRJW+wZ0j8MrK+q30zyC8Dz+1mfB9436uIkSZOx2J7DHwIXAVTVFcAVAEl+vJ/3syOsTZI0IYudN1hfVbfMnthP27LQG5NcnGRvkl0D045PcnWSO/uvxy2paknSSC0WDscuMO+xi7z3EuDMWdMuBK6pqpOBa/pxSdKUWSwcdib5T7MnJvkV4IaF3lhVnwW+MWvyWcCl/fClwMuGK1OSNE6LnXN4HXBlkvN4JAxmgMcAP7+E7a2vqj398NeA9fMtmGQ7sB1g8+bNS9iUJGmpFgyHqnoA2JrkhcCp/eSPVdWnlrvhqqoktcD8HcAOgJmZmXmXkyQdfsM+z+Fa4NrDsL0Hkmyoqj1JNgB7F32HJGnsxn2X81XAtn54G/DhMW9fkjSEkYVDksvobpZ7SpLdSc4H3gL8uyR3Aj/Zj0uSpsyw3Wccsqp6xTyzXjyqbUqSDg87z5MkNQwHSVLDcJAkNQwHTcaatSRZ1mvjJm+OlEZlZCekpQUd2M8577huWau4/IKth6kYSbO55yBJahgOkqSG4SBJahgOkqSG4SBJahgOkqSG4SBJaqz6cNi4abM3W0nSIVr1N8Hdv/teb7aSpEO06vccJEmHznCQJDUMB0lSw3CQJDUMB0lSw3CQJDUMB0lSw3CQJDUMB0lSw3CQJDUMB0lSw3CQJDUMB0lSw3CQJDUMB0lSw3CQJDUMB0lSY9U/Ce6wWLOWJJOuQrMt8/tyxJFH8fD3HlpWCU86cRP33ftPy1qHNI0Mh2Ec2O+jRqfRMr8vl1+w1e+rNA8PK0mSGoaDJKlhOEiSGoaDJKlhOEiSGhO5WinJ3cCDwMPA/qqamUQdkqS5TfJS1hdW1dcnuH1J0jw8rCRJakwqHAr4+yQ3JNk+1wJJtifZmWTnvn37xlyeJD26TSocnl9VzwReArw6yQtmL1BVO6pqpqpm1q1bN/4KJelRbCLhUFX39V/3AlcCPzGJOiRJcxt7OCQ5JskTDg4DPwXsGncdkqT5TeJqpfXAlX1vmmuBv6qqj0+gDknSPMYeDlX1FeDp496uJGl4XsoqSWoYDpKkhuEgSWoYDpKkhuEgSWoYDpKkhuEgSWoYDpKkhuEgSWoYDpKkhuEgSWoYDpKkhuEgSWoYDpKkhuEgSWoYDpKkhuEgSWoYDpKkhuEgSWoYDpKkhuEgSWoYDpKkhuEgSWoYDpKkhuEgSWoYDpKkhuEgSWoYDpKkhuEgSWoYDpKkhuEgSWoYDtJyrFlLkmW91j7m6KlYx8ZNmyfdmqvOxk2bV+z3Ze1EtiqtFgf2c847rlvWKi6/YOvUrEOH1/27712x3xf3HCRJDcNBktQwHCRJDcNBktQwHCRJjYmEQ5Izk9yR5K4kF06iBknS/MYeDkmOAP4b8BLgFOAVSU4Zdx2SpPlNYs/hJ4C7quorVfVd4P3AWROoQ5I0j1TVeDeYnA2cWVW/0o+/EnhOVb1m1nLbge396FOAO4bcxAnA1w9TueNk3eNl3eNl3eN1sO5/U1XrlrKCqb1Duqp2ADsO9X1JdlbVzAhKGinrHi/rHi/rHq/DUfckDivdB2waGD+xnyZJmhKTCIf/CZyc5KQkjwHOBa6aQB2SpHmM/bBSVe1P8hrgE8ARwMVVdeth3MQhH4qaEtY9XtY9XtY9Xsuue+wnpCVJ0887pCVJDcNBktRYNeGwUrrkSLIpybVJbktya5LX9tOPT3J1kjv7r8dNuta5JDkiyf9K8tF+/KQk1/ftfnl/kcFUSXJskg8m+XKS25OcvhLaO8nr+5+RXUkuS3L0tLZ3kouT7E2ya2DanG2czh/3n+HmJM+csrp/t/9ZuTnJlUmOHZh3UV/3HUn+/USKZu66B+a9IUklOaEfX1J7r4pwWGFdcuwH3lBVpwDPBV7d13ohcE1VnQxc049Po9cCtw+MvxV4W1X9MPAvwPkTqWphfwR8vKqeCjydrv6pbu8kG4FfB2aq6lS6izfOZXrb+xLgzFnT5mvjlwAn96/twNvHVONcLqGt+2rg1Kp6GvAPwEUA/e/pucCP9e/5s/5vzyRcQls3STYBPwX808DkJbX3qggHVlCXHFW1p6pu7IcfpPtDtZGu3kv7xS4FXjaRAheQ5ETgp4F39eMBXgR8sF9k6upO8kTgBcC7Aarqu1X1TVZAe9NdTfjYJGuBxwF7mNL2rqrPAt+YNXm+Nj4LeE91vgAcm2TDWAqdZa66q+rvq2p/P/oFunuxoKv7/VX1UFV9FbiL7m/P2M3T3gBvA/4LMHil0ZLae7WEw0bg3oHx3f20qZZkC/AM4HpgfVXt6Wd9DVg/qboW8Id0P3gH+vHvB7458Is0je1+ErAP+Iv+cNi7khzDlLd3Vd0H/B7df4B7gG8BNzD97T1ovjZeSb+v/xH4u354qutOchZwX1V9adasJdW9WsJhxUnyeOBvgNdV1bcH51V3ffFUXWOc5GeAvVV1w6RrOURrgWcCb6+qZwDfYdYhpClt7+Po/uM7CXgScAxzHEZYKaaxjReT5I10h4HfN+laFpPkccBvAf/1cK1ztYTDiuqSI8mRdMHwvqq6op/8wMFdvf7r3knVN4/nAT+X5G66w3YvojuWf2x/2AOms913A7ur6vp+/IN0YTHt7f2TwFeral9VfQ+4gu57MO3tPWi+Np7639ckrwJ+BjivHrkZbJrrfjLdPxJf6n9HTwRuTPKDLLHu1RIOK6ZLjv44/buB26vqDwZmXQVs64e3AR8ed20LqaqLqurEqtpC176fqqrzgGuBs/vFprHurwH3JnlKP+nFwG1MeXvTHU56bpLH9T8zB+ue6vaeZb42vgr45f4qmucC3xo4/DRxSc6kO3z6c1X1rwOzrgLOTXJUkpPoTvB+cRI1zlZVt1TVD1TVlv53dDfwzP7nf2ntXVWr4gW8lO7Kgn8E3jjpehao8/l0u9c3Azf1r5fSHb+/BrgT+CRw/KRrXeAznAF8tB/+IbpfkLuADwBHTbq+Oeo9DdjZt/mHgONWQnsDvw18GdgFvBc4alrbG7iM7tzI9/o/TOfP18ZA6K4u/EfgFrorsqap7rvojtEf/P3884Hl39jXfQfwkmmqe9b8u4ETltPedp8hSWqslsNKkqTDyHCQJDUMB0lSw3CQJDUMB0lSw3CQDkGSLUn+w5DLXpLk7MWXPPTtJplJ8seHY93SXAwH6dBsAYYKh0M1cOfzotutqp1V9eujqEMCw0FTJskxST6W5Ev9cwzO6ac/K8lnktyQ5BMD3TI8u++j/qa+H/5d/fRXJflQ/xyBu5O8Jslv9J3vfSHJ8f1yT07y8X69n0vy1H76JX0f+Ncl+crAHsBbgH/bb+/1s2pPkj/t+/r/JPADA/PuHuhffybJp/vhNyd5b5L/Aby330P4XJIb+9fWubab5Iw88kyN4/vPenP/2Z42sO6Lk3y6/wyGiYY36TsrffkafAG/CLxzYPyJwJHAdcC6fto5wMX98C7g9H74LcCufvhVdHe6PgFYR9er6X/u572NrsND6O7gPbkffg5dtyDQ9Zf/Abp/oE6h6xIeBu4On6P2X6B7FsARdJ3lfRM4u593N4/csToDfLoffjNdb6uP7ccfBxzdD58M7Jxru/z/d6n/CfCmfvhFwE0D676O7s7qE4B/Bo6c9PfY18p4LbQbK03CLcDvJ3kr3R+/zyU5FTgVuLrrZogjgD3pntD1hKr6fP/ev6LrLO2ga6t7ZsaDSb4FfGRgG0/re8bdCnygXy90f0gP+lBVHQBuSzJMl94vAC6rqoeB+5N8asjPfFVV/Z9++EjgT5OcBjwM/MgQ738+XahSVZ9K8v1Jvq+f97Gqegh4KMleum6zdw9Zlx7FDAdNlar6h3SPMXwp8DtJrgGuBG6tqtMHl83A4xvn8dDA8IGB8QN0P/tr6J6PcNoQ7888ywxrP48cxj161rzvDAy/HniA7ol1a4D/u8ztDn6Gh/F3XkPynIOmSpInAf9aVX8J/C5d99p3AOuSnN4vc2SSH6vuiW4PJnlO//ZzD2Vb1T1H46tJfqlfb5I8fZG3PUh3qGounwXOSfec7Q3ACwfm3Q08qx/+xQXW/0RgT7/H8kq6vaTFtvs54Lz+M5wBfL1mPSNEOlSGg6bNjwNfTHIT8Cbgd6p79OvZwFuTfImup8yDJ2rPB97ZL38M3bmFQ3EecH6/3ltZ/PGyNwMP9yfMXz9r3pV0PZDeBrwH+PzAvN8G/ijJTrr/4OfzZ8C2vp6n8shexULbfTPwrCQ305132Ya0TPbKqhUtyeOr6n/3wxcCG6rqtRMuS1rxPP6ole6nk1xE97N8D91VSpKWyT0HSVLDcw6SpIbhIElqGA6SpIbhIElqGA6SpMb/AxcDURY4dCGCAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "durations = [seg.tdur for seg in new_rttm_seq.sequence]\n",
+    "\n",
+    "plot = sns.histplot(data=durations)\n",
+    "plot.set(xlabel=\"Segment duration\")\n",
+    "plot.plot()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[]"
+      ]
+     },
+     "execution_count": 37,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYgAAAEGCAYAAAB/+QKOAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/YYfK9AAAACXBIWXMAAAsTAAALEwEAmpwYAAAcYklEQVR4nO3de5gdVZnv8e8vCaAn3E2fDISEoCIjF4nQEyQgA4IZQBQvKORhJHHQoAPeZxRHR/ByZrwMegbiiBHzBEcmIoNgFAQyXAYVhHRCIOEmiGGSgCQQ7nLEhPf8sVbTxc7a3bsve+90+vd5nv3sqlWrqt6uXbvfXauqVikiMDMzqzWq3QGYmdnmyQnCzMyKnCDMzKzICcLMzIqcIMzMrGhMuwMYSuPGjYvJkye3Owwzs2FjyZIlj0ZER2naFpUgJk+eTFdXV7vDMDMbNiQ9WG+am5jMzKzICcLMzIqcIMzMrMgJwszMipwgzMysyAnCzMyKnCDMzKzICcLMzIqcIMzMrMgJwmwYmzBxEpKGxWvCxEnt3lzWT1tUVxtmI81Dq1dx4nduancYDbn4tGntDsH6yUcQZmZW5ARhZmZFThBmZlbkBGFmZkVNSxCSJkq6XtJdku6U9NFcvrOkRZLuy+871Zl/Zq5zn6SZzYrTzMzKmnkEsQH4ZETsDbwBOF3S3sCZwLURsSdwbR5/CUk7A2cBBwFTgbPqJRIzM2uOpiWIiHg4Ipbm4aeBu4EJwPHAhbnahcDbC7P/FbAoItZHxOPAIuDoZsVqZmabask5CEmTgdcDtwDjI+LhPOn3wPjCLBOAVZXx1bnMzMxapOkJQtK2wKXAxyLiqeq0iAggBrn82ZK6JHWtW7duMIuyJvHdvmbDU1PvpJa0FSk5XBQRP87Fj0jaJSIelrQLsLYw6xrg8Mr4bsANpXVExFxgLkBnZ+egko01h+/2NRuemnkVk4DvAXdHxDcqkxYC3VclzQR+Upj9amC6pJ3yyenpuczMzFqkmU1MhwDvBd4kaVl+HQt8BXizpPuAo/I4kjolXQAQEeuBLwGL8+uLuczMzFqkaU1MEfFLQHUmH1mo3wW8vzI+D5jXnOjMzKwvvpPazMyKnCDMzKzICcLMzIqcIMzMrMgJwszMipwgzMysyAnCzMyKnCDMzKzICcLMzIqcIMzMrMgJwszMipwgzMysyAnCzMyKnCDMzKzICcLMzIqcIMzMrKhpDwySNA84DlgbEfvmsouBvXKVHYEnImJKYd6VwNPARmBDRHQ2K04zMytrWoIA5gNzgO93F0TEid3Dks4Bnuxl/iMi4tGmRWdmZr1q5iNHb5Q0uTRNkoD3AG9q1vrNzGxw2nUO4o3AIxFxX53pAVwjaYmk2b0tSNJsSV2SutatWzfkgZqZjVTtShAzgAW9TD80Ig4AjgFOl3RYvYoRMTciOiOis6OjY6jjNDMbsVqeICSNAd4JXFyvTkSsye9rgcuAqa2JzszMurXjCOIo4J6IWF2aKGmspO26h4HpwIoWxmdmZjQxQUhaANwM7CVptaRT86STqGlekrSrpCvz6Hjgl5JuB24FroiIq5oVp5mZlTXzKqYZdcpnFcoeAo7Nww8A+zcrLjNrk1FjSBcwDg+77jaRNav+p91htFUz74MwM+vxwgZO/M5N7Y6iYRefNq3dIbSdu9owM7MiJwgzMytygjAzsyInCDMzK3KCMDOzIicIMzMrcoIwM7MiJwgzMyvyjXJmVcPsbl+zZnKCMKvy3b5mL3ITk5mZFTlBmJlZkROEmZkVOUGYmVmRE4SZmRU184ly8yStlbSiUna2pDWSluXXsXXmPVrSvZLul3Rms2I0M7P6mnkEMR84ulD+zYiYkl9X1k6UNBr4FnAMsDcwQ9LeTYzTzMwKmpYgIuJGYP0AZp0K3B8RD0TE88APgeOHNDgzM+tTO85BnCHpjtwEtVNh+gRgVWV8dS4rkjRbUpekrnXr1g11rGZmI1arE8S3gVcBU4CHgXMGu8CImBsRnRHR2dHRMdjFmZlZ1tIEERGPRMTGiHgB+C6pOanWGmBiZXy3XGZmZi3U0gQhaZfK6DuAFYVqi4E9Je0haWvgJGBhK+IzM7MeTeusT9IC4HBgnKTVwFnA4ZKmAAGsBE7LdXcFLoiIYyNig6QzgKuB0cC8iLizWXGamVlZ0xJERMwoFH+vTt2HgGMr41cCm1wCa2ZmreM7qc3MrMgJwszMipwgzMysyAnCzMyKnCCyCRMnIWlYvCZMnNTuzWVmI4CfSZ09tHrVsHkWsZ9DbGat4CMIMzMrcoIwM7MiJwgzMytygjAzsyInCDMzK3KCMDOzIicIMzMrcoIwM7Mi3yg3HI0ag6R2R2FmW7hmPjBoHnAcsDYi9s1lXwfeCjwP/BZ4X0Q8UZh3JfA0sBHYEBGdzYpzWHphw7C56xt857fZcNXMJqb5wNE1ZYuAfSPidcBvgM/0Mv8RETHFycHMrD2aliAi4kZgfU3ZNRGxIY/+GtitWes3M7PBaedJ6r8Bfl5nWgDXSFoiaXYLYzIzs6wtJ6klfRbYAFxUp8qhEbFG0v8GFkm6Jx+RlJY1G5gNMGmSu8E2MxsqLT+CkDSLdPL65IiIUp2IWJPf1wKXAVPrLS8i5kZEZ0R0dnR0NCFiM7ORqaEEIemQRsoaWM7RwKeAt0XEH+rUGStpu+5hYDqwor/rMjOzwWn0COK8BsteJGkBcDOwl6TVkk4F5gDbkZqNlkk6P9fdVdKVedbxwC8l3Q7cClwREVc1GKeZmQ2RXs9BSDoYmAZ0SPpEZdL2wOje5o2IGYXi79Wp+xBwbB5+ANi/t2WbmVnz9XWSemtg21xvu0r5U8AJzQrKzMzar9cEERH/Dfy3pPkR8WCLYjIzs81Ao5e5biNpLjC5Ok9EvKkZQZmZWfs1miAuAc4HLiD1j2RmZlu4RhPEhoj4dlMjMTOzzUqjl7n+VNLfStpF0s7dr6ZGZmZmbdXoEcTM/P73lbIAXjm04ZiZ2eaioQQREXs0OxAzM9u8NJQgJJ1SKo+I7w9tOGZmtrlotInpLyrDLwOOBJYCThBmZluoRpuYPlwdl7Qj8MNmBGRmZpuHgXb3/Szg8xJmZluwRs9B/JR01RKkTvpeC/yoWUGZmVn7NXoO4l8qwxuAByNidRPiMTOzzURDTUy50757SD267gQ838ygzMys/Rp9otx7SA/veTfwHuAWSe7u28xsC9boSerPAn8RETMj4hTSM6L/sa+ZJM2TtFbSikrZzpIWSbovv+9UZ96Zuc59kmaW6piZWfM0miBGRcTayvhjDc47Hzi6puxM4NqI2BO4No+/RO7n6SzgIFIyOqteIjEzs+ZoNEFcJelqSbMkzQKuAK7sYx4i4kZgfU3x8cCFefhC4O2FWf8KWBQR6yPicWARmyYaMzNror6eSf1qYHxE/L2kdwKH5kk3AxcNcJ3jI+LhPPx7YHyhzgRgVWV8dS4rxTgbmA0wadKkAYZkZma1+jqC+L+k508TET+OiE9ExCeAy/K0QYmIoOf+ioEuY25EdEZEZ0dHx2BDMjOzrK8EMT4iltcW5rLJA1znI5J2Acjvawt11gATK+O75TIzM2uRvhLEjr1Me/kA17mQnudLzAR+UqhzNTBd0k755PT0XGZmZi3SV4LokvSB2kJJ7weW9LVwSQtI5yv2krRa0qnAV4A3S7oPOCqPI6lT0gUAEbEe+BKwOL++mMvMzKxF+upq42PAZZJOpichdAJbA+/oa+ERMaPOpCMLdbuA91fG5wHz+lqHmZk1R68JIiIeAaZJOgLYNxdfERHXNT0yMzNrq0afB3E9cH2TYzEzs83IQJ8HYWZmWzgnCDMzK3KCMDOzIicIMzMrcoIwM7MiJwgzMytygjAzsyInCDMzK3KCMDOzIicIMzMrcoIwM7MiJwgzMytqqLM+M7MRZ9QYJLU7iobsuttE1qz6nyFfrhOEmVnJCxs48Ts3tTuKhlx82rSmLLflTUyS9pK0rPJ6StLHauocLunJSp3PtzpOM7ORruVHEBFxLzAFQNJoYA1wWaHqLyLiuBaGZmZmFe0+SX0k8NuIeLDNcZiZWY12J4iTgAV1ph0s6XZJP5e0T70FSJotqUtS17p165oTpZnZCNS2BCFpa+BtwCWFyUuB3SNif+A84PJ6y4mIuRHRGRGdHR0dTYnVzGwkaucRxDHA0oh4pHZCRDwVEc/k4SuBrSSNa3WAZmYjWTsTxAzqNC9J+jPlC5AlTSXF+VgLYzMzG/Hach+EpLHAm4HTKmUfBIiI84ETgA9J2gA8B5wUEdGOWM3MRqq2JIiIeBZ4RU3Z+ZXhOcCcVsdlZmY92n0Vk5mZbaacIMzMrMgJwszMipwgzMysyAnCzMyKnCDMzKzICcLMzIqcIMzMrMgJwszMipwgzMysyAnCzMyKnCDMzKzICcLMzIqcIMzMrMgJwszMitr5TOqVkpZLWiapqzBdks6VdL+kOyQd0I44zcxGqrY8MKjiiIh4tM60Y4A98+sg4Nv53czMWmBzbmI6Hvh+JL8GdpS0S7uDMjMbKdqZIAK4RtISSbML0ycAqyrjq3PZS0iaLalLUte6deuaFKqZ2cjTzgRxaEQcQGpKOl3SYQNZSETMjYjOiOjs6OgY2gjNzEawtiWIiFiT39cClwFTa6qsASZWxnfLZWZm1gJtSRCSxkrarnsYmA6sqKm2EDglX830BuDJiHi4xaGamY1Y7bqKaTxwmaTuGP4jIq6S9EGAiDgfuBI4Frgf+APwvjbFamY2IrUlQUTEA8D+hfLzK8MBnN7KuMzMrMfmfJmrmZm1kROEmZkVOUGYmVmRE4SZmRU5QZiZWZEThJmZFTlBmJlZkROEmZkVOUGYmVmRE4SZmRU5QZiZWZEThJmZFTlBmJlZkROEmZkVOUGYmVmRE4SZmRW1PEFImijpekl3SbpT0kcLdQ6X9KSkZfn1+VbHaWY20rXjiXIbgE9GxNL8XOolkhZFxF019X4REce1IT4zM6MNRxAR8XBELM3DTwN3AxNaHYeZmfWurecgJE0GXg/cUph8sKTbJf1c0j69LGO2pC5JXevWrWtWqGZmI07bEoSkbYFLgY9FxFM1k5cCu0fE/sB5wOX1lhMRcyOiMyI6Ozo6mhavmdlI05YEIWkrUnK4KCJ+XDs9Ip6KiGfy8JXAVpLGtThMM7MRrR1XMQn4HnB3RHyjTp0/y/WQNJUU52Oti9LMzNpxFdMhwHuB5ZKW5bJ/ACYBRMT5wAnAhyRtAJ4DToqIaEOsZmYjVssTRET8ElAfdeYAc1oTkZmZlfhOajMzK3KCMDOzIicIMzMrcoIwM7MiJwgzMytygjAzsyInCDMzK3KCMDOzIicIMzMrcoIwM7MiJwgzMytygjAzsyInCDMzK3KCMDOzIicIMzMrcoIwM7Oidj2T+mhJ90q6X9KZhenbSLo4T79F0uQ2hGlmNqK145nUo4FvAccAewMzJO1dU+1U4PGIeDXwTeCrrY3SzMzacQQxFbg/Ih6IiOeBHwLH19Q5HrgwD/8ncKSkXh9TamZmQ0sR0doVSicAR0fE+/P4e4GDIuKMSp0Vuc7qPP7bXOfRwvJmA7Pz6F7AvU3+E/prHLBJ3Jspx9o8wyne4RQrDK94N8dYd4+IjtKEMa2OZKhFxFxgbrvjqEdSV0R0tjuORjjW5hlO8Q6nWGF4xTucYoX2NDGtASZWxnfLZcU6ksYAOwCPtSQ6MzMD2pMgFgN7StpD0tbAScDCmjoLgZl5+ATgumh1W5iZ2QjX8iamiNgg6QzgamA0MC8i7pT0RaArIhYC3wP+XdL9wHpSEhmuNtvmrwLH2jzDKd7hFCsMr3iHU6ytP0ltZmbDg++kNjOzIicIMzMrcoIokPRNSR+rjF8t6YLK+DmSPt/dTYiksyX9XWE5k/M9HYOJJST9oDI+RtI6ST/r53J2lfSfebhT0rkNzHNT/yMuLueZmvFZkuYMcFnFbV2n7uGSpg1kPQ0s+5nK8LGSfiNp92asa7AkbZS0TNIKST+VtGMf9adIOrYy3rTtWFlHcXv25/Nuhcq2vF3S0mZvl3Zzgij7FTANQNIo0s0t+1SmTwOuiYivDOVK8yW9tZ4F9pX08jz+Zja9LLjP5UbEQxFxAkBEdEXER/qaLyKG+85/OPlzrFVnW/ebpCOBc4FjIuLBoVhmEzwXEVMiYl/SRR+n91F/CnBsZfxw6mzHodbq7TmA/aB7W+4PfAb4536ub3Q/11c7f0svLHKCKLsJODgP7wOsAJ6WtJOkbYDXAq8r/QqWdGD+dXE7lS+ipNGSvi5psaQ7JJ2Wyw+X9AtJC4G7JI2VdEVexgrSlWZXAm/Ji5oBLKgsd6qkmyXdJukmSXvl8lmSFkq6Dri2ejST1/mzPHy2pHmSbpD0gKSPVJb9TH7fRdKNlV+hb8x/z/w8vlzSx3PdV0m6StKS/Hf9eS6fL+ncfFTyNeBVuXyypOvyNrlW0qRc3iHp0ry9Fks6pLCtPyDp55JeLukjku7Ky/mhUgePHwQ+nuN+Y47hfEm3AF+rt+0aJekw4LvAcRHx20pMi/Pnd6mk/5XL36rU8eRtkv5L0vjK37lI0p2SLpD0oKRx/Ymjn24GJuR13yCpMw+Pk7RS6dLzLwIn5u32aTbdjn1+NgNR2p410zfZtpJ2yNtsVK4zVtIqSVv1sS++uB8MIuTtgcfzMl/8TuXxOZJm5eGVkr4qaSnwbqUjpHtyXOdWvotj83fx1ryfHJ/LX/JdHkS8/RcRfhVewO+AScBppC/Il0i/qg4BfgHMAubkumcDf5eH7wAOy8NfB1bk4dnA5/LwNkAXsAfp19mzwB552ruA71bieAZ4HalPqpcBy/I8P8vTtwfG5OGjgEvz8CxgNbBzHp9ciaU6/9mkhLgN6UjpMWCr7nXn908Cn83Do4HtgAOBRZU4d8zv1wJ75uGDgOuAjaRfrk/k+B8Cnsh1fgrMzMN/A1yeh/8DODQPTwLurm5r4AzgJ8A2ufyhyvCOtZ9LHp8P/AwY3du2a3D/+FP+m15XU/6KyvCXgQ/n4Z3ouWrw/cA5eXgO8Jk8fDQQwLgh3pe7P8fRwCWkbmwAbgA68/A4YGVl35lTmb92OxY/m0HGWG97vrjuXrbtT4Aj8vCJwAX19sXSftDPODfmffge4EngwNrvVOVznZWHVwKfysMvA1bR831fQM938Z+Av+7eh4HfAGOp+S638jXsu9pooptIh9XTgG+QfnVNI+0UvyrNoNS2u2NE3JiL/p3Uay3AdNJRxwl5fAdgT+B54NaI+F0uXw6cI+mrpJ2YiLgj/yKeQTqaqNoBuFDSnqR/LltVpi2KiPUN/K1XRMQfgT9KWguMJ+2Q3RYD8yRtRfoHvkzSA8ArJZ0HXAFcI2lb0ja6RD19K24DPEe6+XFRRFyUf1l1Xw9+MPDOyvbq/kV3FLB3ZTnb5+UDnEL6kr09Iv6Uy+4ALpJ0OXB5L3/rJRGxMQ/3tu368ifSPnIq8NFK+b6Svkz6gm9Lut8HUo8BF0vaBdia9AME4FDgHQARcZWkx/sRQ6NeLmkZaR++G1g0yOUVP5uIeKaXefpSb3tW1du2F5MSw/Wke6b+rZd9sVt1P+iP5yJiCoCkg4HvS9q3gfkuzu9/DjxQ+b4voKcvuenA29RzzuVlpAQMjX+Xh5SbmOrrPg+xH6mJ6dekf2bTSDtyf4n0i2dKfu0REdfkac92V4qI3wAHkBLFl+n5p7UQ+BcqzUvZl4DrI7Uvv5W0U3V7lsb8sTK8kZobKHPCO4x07mO+pFMi4nFgf9Kv0A8CF5D2pycqf+OUiHhtnfX0ZRTwhspyJlT+AS0nHRHtVqn/FlI38gcAi1W/rba6TXrbdn15AXgPMFXSP1TK5wNnRMR+wBcqyzyP9Kt8P9JRaX/WNVjd/9R2J+2H3U2fG+j5H9CfeHr7bAaq3vasmk952y4Ejpa0M+nI9jr63hcb/W7UFRE3k468OnjptoRNt2cj6xPwrkq8kyLi7qGKdyCcIOq7CTgOWB8RG3P23pGUJIoJIiKeAJ6QdGguOrky+WrgQ/lXOJJeI2ls7TIk7Qr8ISJ+QGqi6j6pNQ/4QkQsr5llB3pOWs/qzx/YKKWrcx6JiO+SEsEBuZ18VERcCnwOOCAingJ+J+ndeT5J2r+Pxd9Ez53yJ5Oa7wCuAT5ciWFKZZ7bSP9kFypdnTUKmBgR1wOfJm2TbYGnSc1h9Qxq20XEH0iJ6WRJp+bi7YCH8+dc/fyr65pZKf8V6R8jkqaTmqKaIsf7EeCTOYGuJP1DhdSlTbfa7VY73ttnM9j4ardnVXHb5uS0GPhXUnPNxgHui/2Sz2mMJjXLPkg6qtomtyQcWWe2e0lH3pPz+ImVaVcDH1Y+5JH0+qGMdyCcIOpbTvp18Ouasiej0O14xfuAb+VD+uozLC4A7gKWKp0s/g7lrk72A27N859FaoIiIlZHROnS1K8B/yzptjrLq6c/t9AfDtye13Ei6Ys4Abghx/kD0hUdkL64pyqdpL+TTZ/1UevDwPsk3QG8l57mhY8AnUonne8iHaX0BB/xS9K5iCuAVwA/kLSclDzOzcn6p8A7lE+uFtY90G1XjWM96dzB5yS9DfhH4BbSP/57KlXPJjV3LOGl3T1/AZie94l3A78n/UNuioi4jdQcN4N0RPqh/PdXT4xfT/pnt0zSiWy6HXv9bAYZX+32rKq3bSE14fw1PU050P99sREvz9thWV7XzJyQVgE/IrU2/Ii0H24iIp4D/ha4Ku8LT5OarSEd0W4F3CHpzjzeVu5qYwSS9C7gbRExs8/K1lRKV8VtjNRH2cHAt7vbuG3L1H2+Jh8pfAu4LyK+2e64SnySeoTJv8r+D+mKIWu/ScCPcjPZ88AH2hyPNd8HJM0kXaxwG6k1YbPkIwgzMyvyOQgzMytygjAzsyInCDMzK3KCsC2WpM8q9XF0R7408aAhXv6Ae6U1Gw58FZNtkfIlo8eRbuD7Y76xb+s2h/UiSaMH2NWDWcv4CMK2VLsAj+Y+poiIRyPiIXixd82vKfVCe6ukV+fyYi+laqDXV0lvyXXGSZqeh5dKuiT3C7RJr54187/Y261Sr7on5PJtlXq5XZrj7e7hc7JSj6DzlZ6dcJGkoyT9StJ9kqbmesUeQs0a0ureAf3yqxUvUlcby0g9Yv4b8JeVaSvp6Z32FHp606zXg2xvPebOIXW29wtSNxnjgBuBsbnOp4HPV9b7qTrxzif1tDoK2Bu4P5ePAbbPw+OA+0l36E8m9f+zX55nCak7FpHuGL48z1PsIbTdn49fw+PlJibbIkW6U/VA4I3AEaSeVM+MiPm5yoLKe/ddrPV6kO2t19c3AZ3A9Ih4StJxpH/wv8rL2Zr0DIZu1a4gal0eES+QngsyPpcJ+CelZyW8QOripHva7yL3zZW7Zrg2IiJ3OTI516nXQ2h3J3BmdTlB2BYrUhv/DaQ+o5aTOsmb3z25WjW/d/dS+v+qy8knoq+PiHfkTtZuqEz+LfBK4DWkZ3yI1DXzjDph9dYrZ7W32+4sdTKpt9ADI+JPklbS01Notf4LlfEX6Plud/cQem8v6zUr8jkI2yJJ2iv/4u82hdTjZrcTK+/dv/Dr9VLaW6+vD5Ie8vR9SfuQOnc8pHJeY6yk1wziT9kBWJuTwxGkLrv7Y7PrIdSGDycI21JtS2oWuiv3FLs3qUfVbjvl8o8CH89l9Xop7bXX14i4h/RL/xLS+YpZwIK8/JtJD4kZqItyTMtJ50tqezHty2bXQ6gNH+6LyUac3EzTGb1322424vkIwszMinwEYWZmRT6CMDOzIicIMzMrcoIwM7MiJwgzMytygjAzs6L/D+ep+1tSNfabAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "speakers = [seg.name for seg in new_rttm_seq.sequence]\n",
+    "\n",
+    "plot = sns.histplot(data=speakers)\n",
+    "plot.set(xlabel=\"Speaker name\")\n",
+    "plot.plot()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 50,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[]"
+      ]
+     },
+     "execution_count": 50,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAX4AAAEGCAYAAABiq/5QAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/YYfK9AAAACXBIWXMAAAsTAAALEwEAmpwYAAAae0lEQVR4nO3de7gcVZnv8e+PEO73SR4OgiGgiCK3gX1QQFEBGUREHUTM4RZlCDrcZFCEg4rOyIziOB4RHQnIRASiXBwMOCI5BAS5SUJCAgmgIggiw2YQFWG4JO/8sVaTSrO7d+3eu7rTqd/nefrpqurqWu/urnr36tVVbysiMDOz+lit1wGYmVl3OfGbmdWME7+ZWc048ZuZ1YwTv5lZzaze6wDKmDBhQkyePLnXYZiZ9ZV58+Y9GRETm5f3ReKfPHkyc+fO7XUYZmZ9RdLDQy33UI+ZWc048ZuZ1YwTv5lZzTjxm5nVjBO/mVnNOPGbmdWME7+ZWc048ZuZ1YwTv5lZzfTFlbtmZt2y5Kw5vQ5hBW84Y+8x32ZlPX5JF0p6QtI9hWVflnSfpIWS/l3SRlW1b2ZmQ6tyqGcGsH/TstnA9hGxI/AAcHqF7ZuZ2RAqS/wRcRPwVNOy6yLipTx7O7BFVe2bmdnQevnl7keAH7d6UNI0SXMlzR0cHOxiWGZmq7aeJH5JZwAvAZe0WicipkfEQEQMTJz4inLSZmbWoa6f1SNpKnAgsE9ERLfbNzOru64mfkn7A6cCb4uIZ7vZtpmZJVWezjkTuA3YVtKjko4GzgXWB2ZLWiDpW1W1b2ZmQ6usxx8RU4ZY/O2q2jMzs3JcssHMrGac+M3MasaJ38ysZpz4zcxqxonfzKxmnPjNzGrGid/MrGac+M3MasaJ38ysZpz4zcxqxonfzKxmnPjNzGrGid/MrGac+M3MasaJ38ysZrr+04vdtusnL+p1CCuY9+Ujex2CmdWce/xmZjXjxG9mVjNO/GZmNePEb2ZWM078ZmY1s8qf1WO2qjj3lKt7HcIKjv/Ke3odgnXIPX4zs5px4jczq5nKEr+kCyU9IemewrJNJM2W9It8v3FV7ZuZ2dCq7PHPAPZvWnYacH1EbANcn+fNzKyLKkv8EXET8FTT4vcC38nT3wHeV1X7ZmY2tG6P8W8aEb/L048Dm3a5fTOz2uvZl7sREUC0elzSNElzJc0dHBzsYmRmZqu2bif+/5S0GUC+f6LVihExPSIGImJg4sSJXQvQzGxV1+3EPws4Kk8fBfywy+2bmdVeladzzgRuA7aV9Kiko4EvAu+U9Atg3zxvZmZdVFnJhoiY0uKhfapq08zMhucrd83MasZF2lZCv/n7HXodwgomfXZRr0OwPnXW4R/odQgrOOPiK3odwkrBPX4zs5px4jczqxknfjOzmnHiNzOrGX+5a2Niz6/v2esQXnbLCbf0OgSzlZp7/GZmNePEb2ZWM078ZmY148RvZlYzpb7czb+N+yrgOeChiFhWaVRmZlaZlolf0obAccAUYA1gEFgL2FTS7cA3I+KGrkRpZmZjpl2P/wrgIuCtEfF08QFJuwJHSNo6Ir5dYXxmZjbGWib+iHhnm8fmAfMqicjMzCpVdox/c2DL4voRcVNVQZmZWXWGTfySvgQcCiwGlubFATjxm5n1oTI9/vcB20bE8xXHYmZmXVDmPP4HgfFVB2JmZt1Rpsf/LLBA0vXAy73+iDixsqjMzKwyZRL/rHwzM7NVwLCJPyK+041AzMysO9pduXtZRHxQ0iLSWTwriIgdK43MzMwq0a7Hf1K+P7AbgZiZWXe0u3L3d/n+YQBJG7Rb38zM+sOwp3NKOlbS48BCUpmGecDc0TQq6WRJ90q6R9JMSWuNZntmZlZemfP4PwFsHxGTI2KrfNu60wZz+YcTgYGI2B4YB3yo0+2ZmdnIlEn8vyKdyz+WVgfWlrQ6sA7w2Bhv38zMWigzZn86cKukOxiDC7gi4reS/hn4DemHXa6LiOua15M0DZgGMGnSpE6aMjOzIZTp8Z8HzAFuZ/kYf8clmfOveb0X2Ir0q17rSjq8eb2ImB4RAxExMHHixE6bMzOzJmV6/OMj4u/GsM19gV9HxCCApB8AewAXj2EbZmbWQpke/48lTZO0maRNGrdRtPkb4M2S1pEkYB9gySi2Z2ZmI1Cmxz8l359eWBZAR2f2RMQdkq4A7gJeAuYD0zvZlpmZjVyZWj1bjXWjEXEmcOZYb9fMzIbXcqhH0lvaPVHSBpK2H/uQzMysSu16/AdLOhu4lnQWzyCwFvBa4B2k3+A9pfIIzcxsTLWr1XNy/hL3YOAQYDPSefdLgPMi4mfdCdHMzMZS2zH+iHgKOD/fzMxsFVDmdE4zM1uFOPGbmdWME7+ZWc2Uqce/jqTPSDo/z28jyb/KZWbWp8r0+P+NVJVz9zz/W+ALlUVkZmaVKpP4XxMRZwMvAkTEs4AqjcrMzCpTJvG/IGltUn0eJL2GQl1+MzPrL2WKtJ1Junr31ZIuAfYEplYZlJmZVadMkbbZku4C3kwa4jkpIp6sPDIzM6tE2dM5Nyf9KPoawF6S/rq6kMzMrErD9vglXQjsCNwLLMuLA/hBhXGZmVlFyozxvzkitqs8EjMz64oyQz23SXLiNzNbRZTp8V9ESv6Pk07jFBARsWOlkZmZWSXKJP5vA0cAi1g+xm9mZn2qTOIfjIhZlUdiZmZdUSbxz5d0KXA1hSt2I8Jn9ZiZ9aEyiX9tUsLfr7DMp3OamfWpMlfufrgbgZiZWXe0TPySTo2IsyV9nVygrSgiTqw0MjMzq0S7Hv+SfD+3G4GYmVl3tEz8EXF1nnw2Ii4vPibpkNE0Kmkj4AJge9KniY9ExG2j2aaZmZVT5srd00suG4mvAddGxOuBnVj+6cLMzCrWboz/XcABwOaSzik8tAHwUqcNStoQ2Itc0z8iXgBe6HR7ZmY2Mu16/I+Rxvf/G5hXuM0C/moUbW4FDAL/Jmm+pAskrdu8kqRpkuZKmjs4ODiK5szMrKjdGP/dwN2SLo2IF8e4zV2AEyLiDklfA04DPtPU/nRgOsDAwMArzioyM7PODDvGP8ZJH+BR4NGIuCPPX0H6R2BmZl1Q9he4xkxEPA48ImnbvGgfYHG34zAzq6syJRuqcAJwiaQ1gAcBXx1sZtYlZX568XXAJ4Eti+tHxN6dNhoRC4CBTp9vZmadK9Pjvxz4FnA+sLTacMzMrGplEv9LEfGvlUdiZmZd0e4Crk3y5NWS/hb4d1asx/9UxbGZmVkF2vX455Hq6CjPf7LwWABbVxWUmZlVp90FXFt1MxAzM+uOYc/jl3RcrqbZmN84D/2YmVkfKnMB1zER8XRjJiJ+DxxTWURmZlapMol/nKTGOD+SxgFrVBeSmZlVqczpnNcC35d0Xp4/Ni8zM7M+VCbxf4qU7D+W52eTfj3LzMz60LCJPyKWSZoBzImI+6sPyczMqlTmrJ6DgAXk4R1JO0uaVXFcZmZWkTJf7p4J7AY8DS8XWPM5/mZmfapM4n8xIv7QtMy/iGVm1qfKfLl7r6T/QzqtcxvgRODWasMyM7OqlOnxnwC8kVSg7VLgD8DHK4zJzMwqVOasnmeBMySdlafNzKyPlTmrZw9Ji4H78vxOkr5ZeWRmZlaJMkM9XwX+CvgvgIi4G9iryqDMzKw6ZRI/EfFI0yL/BKOZWZ8qc1bPI5L2AELSeOAkYEm1YZmZWVXK9Pg/ChwHbA48Buyc583MrA+VOavnSeCwLsRiZmZdUOasnq0lXS1pUNITkn4oyb+3a2bWp8oM9VwKXAZsBrwKuByYWWVQZmZWnTKJf52I+G5EvJRvFwNrjbZhSeMkzZd0zWi3ZWZm5ZVJ/D+WdJqkyZK2lHQq8B+SNpG0ySja9tlBZmY9UOZ0zg/m+2Obln+IVKVzxOP9krYA3g2cBfzdSJ9vZmadK3NWTxW19/8fcCqwfqsVJE0DpgFMmjSpghDMzOqp5VCPpP8t6X8V5o/MZ/ScM5ohHkkHAk9ExLx260XE9IgYiIiBiRMndtqcmZk1aTfGfx7wAoCkvYAvAheRyjJPH0WbewIHSXoI+B6wt6SLR7E9MzMbgXaJf1xEPJWnDwWmR8SVEfEZ4LWdNhgRp0fEFhExmfQ9wZyIOLzT7ZmZ2ci0TfySGt8B7APMKTxW5kthMzNbCbVL4DOBn0p6EngOuBlA0mtJwz2jFhE3AjeOxbbMzKyclok/Is6SdD3pit3rIqLxA+urkX6O0czM+lDbIZuIuH2IZQ9UF46ZmVWt1A+xmJnZqsOJ38ysZpz4zcxqxonfzKxmnPjNzGrGid/MrGac+M3MasaJ38ysZpz4zcxqxonfzKxmnPjNzGrGid/MrGac+M3MasaJ38ysZpz4zcxqxonfzKxmnPjNzGrGid/MrGba/vSi2arqp3u9rdchrOBtN/201yFYjbjHb2ZWM078ZmY148RvZlYzTvxmZjXT9cQv6dWSbpC0WNK9kk7qdgxmZnXWi7N6XgJOiYi7JK0PzJM0OyIW9yAWM7Pa6XqPPyJ+FxF35ek/AUuAzbsdh5lZXfV0jF/SZOAvgTuGeGyapLmS5g4ODnY9NjOzVVXPEr+k9YArgY9HxB+bH4+I6RExEBEDEydO7H6AZmarqJ4kfknjSUn/koj4QS9iMDOrq16c1SPg28CSiPiXbrdvZlZ3vejx7wkcAewtaUG+HdCDOMzMaqnrp3NGxM8AdbtdMzNLfOWumVnNOPGbmdWME7+ZWc048ZuZ1YwTv5lZzTjxm5nVjBO/mVnNOPGbmdWME7+ZWc048ZuZ1YwTv5lZzTjxm5nVjBO/mVnNOPGbmdWME7+ZWc048ZuZ1YwTv5lZzTjxm5nVjBO/mVnNOPGbmdWME7+ZWc048ZuZ1YwTv5lZzTjxm5nVjBO/mVnN9CTxS9pf0v2SfinptF7EYGZWV11P/JLGAd8A3gVsB0yRtF234zAzq6te9Ph3A34ZEQ9GxAvA94D39iAOM7NaUkR0t0HpA8D+EfE3ef4I4E0RcXzTetOAaXl2W+D+rgb6ShOAJ3scw0g55ur1W7zgmLtlZYh5y4iY2Lxw9V5EUkZETAem9zqOBklzI2Kg13GMhGOuXr/FC465W1bmmHsx1PNb4NWF+S3yMjMz64JeJP47gW0kbSVpDeBDwKwexGFmVktdH+qJiJckHQ/8BBgHXBgR93Y7jg6sNMNOI+CYq9dv8YJj7paVNuauf7lrZma95St3zcxqxonfzKxm+jrxSwpJFxfmV5c0KOmaEW7nVZKuyNMDks4p8ZxbRx5xy2090zQ/VdK5HW7rc5I+UXLdt0vao5N2RhDPM4XpAyQ9IGnLKtscCUlLJS2QdLeku6p+PUZD0lclfbww/xNJFxTmvyLps40yKK32BUmTJd3TlaBXbHfIfWEk+2yvFPaTeyRdLWmjYdbfWdIBhfnKj7WR6OvED/wZ2F7S2nn+nYzw1FBJq0fEYxHxAYCImBsRJw73vIhYad7EUXg7MOTfIWlMv/iXtA9wDvCuiHh4LLc9Ss9FxM4RsRNwOvBPI3lyLkHSsRG+zreQ3y9Jq5EuEHpj4fE9gOsi4oujialZv+8LYxR/Yz/ZHngKOG6Y9XcGDijMv50Wx1ov9HviB/gP4N15egows/GApN0k3SZpvqRbJW2bl0+VNEvSHOD6Yg8o/2e+Jk9/TtKFkm6U9KCkEwvbfibfbybppkJv4K2SxkmakecXSTo5r/saSddKmifpZkmvz5tbU9I5OcYHgYFCO5MlzZG0UNL1kibl5RMlXSnpznzbs/mFkXSMpB9LWlvSiZIW5+18T9Jk4KPAyTn2t+aYvyXpDuDsVq/fSEnaCzgfODAiflWI7c7c075S0jp5+Xsk3ZHb/P+SNi38vbMl3SvpAkkPS5rQSTxtbAD8Prf38n6Q58+VNDVPPyTpS5LuAg7Jvdf78vt6TmH/WTfvPz/Pf8978/IV9r8RxHcrsHuefiNwD/AnSRtLWhN4A7Cjhvi0KGnX/FrfTSFp5X31y/m9WCjp2MLff7OkWcDi/Lf8KG/jHkmHjiDuYhyv2BeaHn/FfiFpw/x+r5bXWVfSI5LGtzqmmvflTmJt4zZg89zOjZIG8vSEvG+sAfw9cGg+tj7FK4+1YY/fSkVE396AZ4AdgSuAtYAFpP+s1+THNwBWz9P7Alfm6anAo8AmeX4ycE+eLj7/c6SDbU1S7+q/gPGNtvP9KcAZeXocsD6wKzC7EOdG+f56YJs8/SZgTp5eBjyd418CvAicmx+7GjgqT38EuCpPXwq8JU9PApYUYv4EcDzwQ2DNvPyxwvRGxXULcc4ArgHGtXv9RvgevUjqIe3YtPwvCtNfAE7I0xuz/GyzvwG+kqfPBU7P0/sDAUwYg31oaX7d7wP+AOzavB8U2p+apx8CTs3TawGPAFvl+ZmF/ecfgcMbrznwALAuTfvfCOP9dX6/jyUlk38g9Sz3BG7O227sOy+/v8BCYK88/WWW7+/TgE/n6TWBucBW+e//c+HvOhg4vxDHhmO4LxTjbLVf/BB4R54+FLhgmGNqBoV9eQz2k8bxPg64nFR2BuBGYCBPTwAeytMvvw8tjrUhj99u3Vbakg1lRcTC3HudQur9F20IfEfSNqREMb7w2OyIeKpEEz+KiOeB5yU9AWxKOmgb7gQulDSelJQXKPXat5b0deBHwHWS1iN91LtcUuO5a+b7pcBxEXEJgKTnCtvfHfjrPP1dlvde9gW2K2xrg9wGwJGkZPS+iHgxL1sIXCLpKuCqNn/v5RGxNE+3e/3KepH0z/No4KTC8u0lfYGUENcjXdcB6Uru70vaDFiDlOgA3gK8HyAirpX0+w5iGcpzEbEzgKTdgYskbV/ied/P968HHoyIRpwzWV5jaj/gIC0fv16LdJBD+f2v2a2k/WgP4F9IPc89SP+0bhnqCUrj0RtFxE150XdJ1XEbMe6oVEML0nu+DfAC8PPC37UI+IqkL5H+sd3cQeyt9oWiVvvF90kJ/wbSRZ/fHOaYghX35dFaW9IC0uu9BJg9yu0NefxGxDNtnjNmVoWhHkhX/v4zhWGe7B+AGyKNy72HdOA1/Lnktp8vTC+l6aK3fDDtRfpuYYakIyPi98BOpN7AR4ELSK/105HGCRu3N7RoRwxvNeDNhW1tXthpFpE+xWxRWP/dpHLYuwB3qvW4Z/F1aff6lbUM+CCwm6T/W1g+Azg+InYAPl/Y9tdJPaUdSL3aTtrsSETcRuq1TQReYsXjozmOMvuPgIML79GkiFgygucPpTHOvwNpqOd2UudgD1JSHSmRetWNGLeKiOuaY4yIB0j7ziLgC5I+20FbrfaFohkMvV/MAvaXtAnpE/Uchj+mOn2Nh9LoIGxJes0aw2XF/WQk+2q747dyq0rivxD4fEQsalq+Icu/7J1aRcNKZ6j8Z0ScT0rwu+Sx59Ui4krg08AuEfFH4NeSDsnPk6SdSjRxK6mHA3AY6eM8wHXACYU4di48Zz4pac5SOmNpNeDVEXED8CnS67Ie8CfS0FQrY/L6RcSzpH88h0k6Oi9eH/hd/qR0WIs2jyosv4WUNJC0H2lIaEzl8eFxpCG9h0k9sjVzj3mfFk+7n/TpbnKeL459/wQ4QblbJ+kvxyDMW4EDgaciYmn+1LARKfkPmfgj4mngaUlvyYuKr/dPgI/l9wFJr5O0bvM2JL0KeDYiLiYNFe3SSfAt9oWiIfeLnBTvBL5G+sSxdBTHVMdy/CcCp+TO00Okf0QAHyis2nxsNc+3O34rt0ok/oh4NCKGOgXzbOCfJM1nZOUpRnI589uBu3Mbh5J2zM2BG/NHw4tJZ4tA2pGPzl+w3Uu53yE4AfiwpIXAESz/iHwiMJC/kFtM+mSx/A+I+BlprP9HwF8AF0taRPqncE5OBlcD72984TRE252+fq+QE9T+wKclHQR8BriDlNDvK6z6OdJH93msWNL288B+Sl/CHwI8TjqYRmvt/PcvIA0nHJWTyiPAZaRe9WWk122ov+s54G+Ba3PMfyINu0D6xDQeWCjp3jw/WotIn0pub1r2h4hoVwL4w8A38t9Z/ER5AbAYuCu/tucx9Hu9A/Dz/PwzSePvHRliXyhqtV9Aen8OZ/kwG3R2TI1KRMwnDZ1OIY00fCwfI8WTDW4gdRwWKH0R3nystT1+q+aSDU0kHQwcFBFHDbuydY3SWStLI9V62h3418bYfK81xmZzz/4bwC8i4qu9jsuslb7/cncs5d7HWaSzZ2zlMgm4LA9bvQAc0+N4io6RdBTpy+j5pF6z2UrLPX4zs5pZJcb4zcysPCd+M7OaceI3M6sZJ37rO5LOUKrZszCfHvemMd5+x9VRzfqBz+qxvpJP5TyQdFHc8/liuTV6HNbLJI0bwzIBZpVwj9/6zWbAk7l+EhHxZEQ8Bi9XzTxbqSLqzyW9Ni8fshKiSlQflfTuvM4ESfvl6bskXZ5rxbyiWmfT82eoUHlVuSaOpPWUqq3eleNtVO6crFTpc4ZSvfpLJO0r6RZJv5C0W15vyMqfZqV0syKcb76N9kYqNbGAVOnym8DbCo89xPJKqUeyvEpmq0qm7aq3nksqCnczqTzEBOAmYN28zqeAzxbaPbVFvDNI1RxXA7YDfpmXrw5skKcnAL8kXVE7mVT/ZYf8nHmkkiQiXZV6VX7OkJU/e/3++NYfNw/1WF+JdIXsrsBbgXeQKnmeFhEz8iozC/eNq2dbVTJtV310b9LvIuwXEX+UdCApcd+St7MGqS57Q7GMQLOrImIZqa79pnmZgH9Uqk+/jFTmo/HYryPXncqlHq6PiMglNybndVpV/mwUgTNryYnf+k6kMfQbSfWQFpGKuc1oPFxcNd83KiH+d3E7+QvcGyLi/UpF1m4sPPwrYGvgdaQa9SKVUp7SIqx2lSCHqrx6GKkK6K4R8aKkh1he3bG4/rLC/DKWH7ONyp/3t2nXbEge47e+Imnb3ENv2JlUSbPh0MJ9o0feqhJiu+qjD5N+fOQiSW8kFUXbs/C9wbqSXjeKP2VD4Imc9N9BKvc7ElVU/rSacOK3frMeaXhmca5Yuh2pomfDxnn5ScDJeVmrSohtq49GxH2knvnlpO8DpgIz8/ZvI/0IS6cuyTEtIn0f0VyJcjhVVP60mnCtHltl5OGSgWhfntis9tzjNzOrGff4zcxqxj1+M7OaceI3M6sZJ34zs5px4jczqxknfjOzmvkfmR26ChMXBFsAAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "speaker_time = []\n",
+    "\n",
+    "for spk in set(speakers):\n",
+    "    speaker_time.append(\n",
+    "        sum([dur for i, dur in enumerate(durations) if speakers[i] == spk])/60.0)\n",
+    "\n",
+    "plot = sns.barplot(data={\"time\": speaker_time, \"speaker\": list(\n",
+    "    set(speakers))}, x=\"speaker\", y=\"time\")\n",
+    "plot.set(xlabel=\"Speaker name\", ylabel=\"Speech time (min)\")\n",
+    "plot.plot()\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "interpreter": {
+   "hash": "b6f083d5ac60cf7759826377c3d8f491f9a0109c460299bd7207c8484c8eacf0"
+  },
+  "kernelspec": {
+   "display_name": "Python 3.9.7 ('mexca-sd-experiment': venv)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.7"
+  },
+  "orig_nbformat": 4
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/rttm.py
+++ b/rttm.py
@@ -1,11 +1,19 @@
 """Storing and writing data in RTTM format"""
 
+<<<<<<< Updated upstream
+=======
+from click import FileError
+from copy import deepcopy
+>>>>>>> Stashed changes
 from dataclasses import dataclass, field
 import sys
 import numpy as np
 
+<<<<<<< Updated upstream
 from click import FileError
 
+=======
+>>>>>>> Stashed changes
 
 @dataclass
 class RttmObj:
@@ -32,6 +40,23 @@ class RttmObj:
         self.check_attrs()
 
 
+<<<<<<< Updated upstream
+=======
+    def __copy__(self):
+        return type(self)(
+            self.type,
+            self.file,
+            self.chnl,
+            self.tbeg,
+            self.tdur,
+            self.ortho,
+            self.stype,
+            self.name,
+            self.conf
+        )
+
+
+>>>>>>> Stashed changes
 def get_default_header():
     return ["type", "file", "chnl", "tbeg", "tdur", "ortho", "stype", "name", "conf"]
 
@@ -47,6 +72,25 @@ class RttmSeq:
     sequence: list[RttmObj]
     header: list[str] = field(default_factory=get_default_header)
 
+<<<<<<< Updated upstream
+=======
+
+    def __copy__(self):
+        return type(self)(self.sequence, self.header)
+
+
+    def __deepcopy__(self, memo):
+        id_self = id(self)
+        _copy = memo.get(id_self)
+        if _copy is None:
+            _copy = type(self)(
+                deepcopy(self.sequence, memo), 
+                deepcopy(self.header, memo))
+            memo[id_self] = _copy 
+        return _copy
+
+
+>>>>>>> Stashed changes
     def __str__(self, end="\t", file=sys.stdout, header=True):
         if header:
             for h in self.header:
@@ -68,6 +112,19 @@ class RttmSeq:
         return ""
 
 
+<<<<<<< Updated upstream
+=======
+    def sort(self):
+        indices = np.argsort([seg.tbeg for seg in self.sequence])
+
+        sorted_segments = [self.sequence[i] for i in indices]
+        
+        self.sequence = sorted_segments
+
+        return self
+
+
+>>>>>>> Stashed changes
     def write(self, filename):
         check_rttm_filename(filename)
         with open(filename, "w") as file:

--- a/test_rttm.py
+++ b/test_rttm.py
@@ -1,4 +1,8 @@
 from click import FileError
+<<<<<<< Updated upstream
+=======
+from copy import copy, deepcopy
+>>>>>>> Stashed changes
 from rttm import RttmSeq, RttmObj, get_default_header, read_rttm
 import pytest
 
@@ -70,6 +74,22 @@ class TestRttmObj:
                 conf = 1.4
             )
 
+<<<<<<< Updated upstream
+=======
+    
+    def test_copy(self):
+        obj = RttmObj(
+            type = "",
+            file = "",
+            chnl = 1,
+            tbeg = 1.0,
+            tdur = 1.0
+        )
+        obj_copy = copy(obj)
+
+        assert obj is not obj_copy
+
+>>>>>>> Stashed changes
 
 class TestRttmSeq:
     def test_init(self):
@@ -93,6 +113,78 @@ class TestRttmSeq:
         assert hasattr(obj, "sequence")
 
 
+<<<<<<< Updated upstream
+=======
+    def test_copy(self):
+        seq = [
+            RttmObj(
+                type = "",
+                file = "",
+                chnl = 1,
+                tbeg = 1.0,
+                tdur = 1.0
+            ),
+            RttmObj(
+                type = "",
+                file = "",
+                chnl = 1,
+                tbeg = 1.0,
+                tdur = 1.0
+            )
+        ]
+        obj = RttmSeq(seq)
+        obj_copy = copy(obj)
+
+        assert obj is not obj_copy
+
+
+    def test_deepcopy(self):
+        seq = [
+            RttmObj(
+                type = "",
+                file = "",
+                chnl = 1,
+                tbeg = 1.0,
+                tdur = 1.0
+            ),
+            RttmObj(
+                type = "",
+                file = "",
+                chnl = 1,
+                tbeg = 1.0,
+                tdur = 1.0
+            )
+        ]
+        obj = RttmSeq(seq)
+        obj_copy = deepcopy(obj)
+
+        assert obj.sequence[0] is not obj_copy.sequence[0]
+
+
+    def test_sort(self):
+        seq = [
+            RttmObj(
+                type = "",
+                file = "",
+                chnl = 1,
+                tbeg = 2.0,
+                tdur = 1.0
+            ),
+            RttmObj(
+                type = "",
+                file = "",
+                chnl = 1,
+                tbeg = 0.0,
+                tdur = 1.0
+            )
+        ]
+        obj = RttmSeq(seq)
+        obj_sorted = obj.sort()
+        
+        assert obj_sorted.sequence[0].tbeg < obj_sorted.sequence[1].tbeg
+
+
+>>>>>>> Stashed changes
     def test_read_write(self):
         test_filename = "test.rttm"
         seq = [


### PR DESCRIPTION
Closes Nlesc-team/Sushi#48

I created a notebook to create the Dutch Debate 21 dataset from the video file and annotations Gijs and Christian gave us. You will need to copy the folder `dutch-debate-corpus` that I put in our OneDrive into the repository to run the notebook.

I also added a few methods for copying and sorting RTTM objects to the `rttm.py` file.